### PR TITLE
Allow classnames for ChatFeed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffersonl-surge/react-chat-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A library of React components for building chat UI's",
   "repository": "https://github.com/jefferson-surge/react-chat-ui",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffersonl-surge/react-chat-ui",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A library of React components for building chat UI's",
   "repository": "https://github.com/jefferson-surge/react-chat-ui",
   "main": "./lib/index.js",

--- a/src/BubbleGroup/index.tsx
+++ b/src/BubbleGroup/index.tsx
@@ -23,6 +23,7 @@ export default class BubbleGroup extends React.Component {
       chatBubble,
       senderName,
       classNameArray,
+      styleArray,
     } = this.props;
     const ChatBubble = chatBubble || DefaultChatBubble;
     const sampleMessage = messages[0];
@@ -35,6 +36,7 @@ export default class BubbleGroup extends React.Component {
           bubblesCentered={bubblesCentered}
           bubbleStyles={bubbleStyles}
           classNameString={classNameArray && classNameArray.length > i ? classNameArray[i] : undefined}
+          style={styleArray && styleArray.length > i ? styleArray[i] : undefined}
         />
       );
     });

--- a/src/BubbleGroup/index.tsx
+++ b/src/BubbleGroup/index.tsx
@@ -22,6 +22,7 @@ export default class BubbleGroup extends React.Component {
       showSenderName,
       chatBubble,
       senderName,
+      classNameArray,
     } = this.props;
     const ChatBubble = chatBubble || DefaultChatBubble;
     const sampleMessage = messages[0];
@@ -33,6 +34,7 @@ export default class BubbleGroup extends React.Component {
           message={message}
           bubblesCentered={bubblesCentered}
           bubbleStyles={bubbleStyles}
+          classNameString={classNameArray && classNameArray.length > i ? classNameArray[i] : undefined}
         />
       );
     });

--- a/src/BubbleGroup/interface.ts
+++ b/src/BubbleGroup/interface.ts
@@ -6,4 +6,5 @@ export default interface BubbleGroupInterface {
   showSenderName: boolean;
   chatBubble: ChatBubble;
   bubbleStyles: any;
+  classNameArray?: string[];
 };

--- a/src/BubbleGroup/interface.ts
+++ b/src/BubbleGroup/interface.ts
@@ -7,4 +7,5 @@ export default interface BubbleGroupInterface {
   chatBubble: ChatBubble;
   bubbleStyles: any;
   classNameArray?: string[];
+  styleArray?: object[];
 };

--- a/src/ChatBubble/index.tsx
+++ b/src/ChatBubble/index.tsx
@@ -25,20 +25,20 @@ export default class ChatBubble extends React.Component {
     const chatBubbleStyles =
       this.props.message.id === 0
         ? {
-            ...styles.chatbubble,
-            ...bubblesCentered ? {} : styles.chatbubbleOrientationNormal,
-            ...chatbubble,
-            ...userBubble,
-          }
+          ...styles.chatbubble,
+          ...bubblesCentered ? {} : styles.chatbubbleOrientationNormal,
+          ...chatbubble,
+          ...userBubble,
+        }
         : {
-            ...styles.chatbubble,
-            ...styles.recipientChatbubble,
-            ...bubblesCentered
-              ? {}
-              : styles.recipientChatbubbleOrientationNormal,
-            ...userBubble,
-            ...chatbubble,
-          };
+          ...styles.chatbubble,
+          ...styles.recipientChatbubble,
+          ...bubblesCentered
+            ? {}
+            : styles.recipientChatbubbleOrientationNormal,
+          ...userBubble,
+          ...chatbubble,
+        };
 
     return (
       <div
@@ -46,7 +46,7 @@ export default class ChatBubble extends React.Component {
           ...styles.chatbubbleWrapper,
         }}
       >
-        <div style={chatBubbleStyles}>
+        <div style={chatBubbleStyles} className={this.props.classNameString || ""}>
           <p style={{ ...styles.p, ...text }} dangerouslySetInnerHTML={{ __html: this.props.message.message }}></p>
         </div>
       </div>

--- a/src/ChatBubble/index.tsx
+++ b/src/ChatBubble/index.tsx
@@ -29,6 +29,7 @@ export default class ChatBubble extends React.Component {
           ...bubblesCentered ? {} : styles.chatbubbleOrientationNormal,
           ...chatbubble,
           ...userBubble,
+          ...this.props.style,
         }
         : {
           ...styles.chatbubble,
@@ -38,6 +39,7 @@ export default class ChatBubble extends React.Component {
             : styles.recipientChatbubbleOrientationNormal,
           ...userBubble,
           ...chatbubble,
+          ...this.props.style,
         };
 
     return (

--- a/src/ChatBubble/interface.ts
+++ b/src/ChatBubble/interface.ts
@@ -7,4 +7,5 @@ export default interface ChatBubbleProps {
     text: object
   }
   bubblesCentered: boolean
+  classNameString?: string
 }

--- a/src/ChatBubble/interface.ts
+++ b/src/ChatBubble/interface.ts
@@ -8,4 +8,5 @@ export default interface ChatBubbleProps {
   }
   bubblesCentered: boolean
   classNameString?: string
+  style?: object
 }

--- a/src/ChatFeed/index.tsx
+++ b/src/ChatFeed/index.tsx
@@ -20,6 +20,7 @@ interface ChatFeedInterface {
     messages: any;
     showSenderName?: boolean;
     chatBubble?: React.Component;
+    classNameArray?: string[];
   };
 }
 
@@ -60,12 +61,17 @@ export default class ChatFeed extends React.Component {
     const ChatBubble = chatBubble || DefaultChatBubble;
 
     let group = [];
+    let classNamesForGroup = [];
 
     const messageNodes = messages.map((message, index) => {
       group.push(message);
+      if (this.props.classNameArray && this.props.classNameArray.length > index) {
+        classNamesForGroup.push(this.props.classNameArray[index])
+      }
       // Find diff in message type or no more messages
       if (index === messages.length - 1 || messages[index + 1].id !== message.id) {
         const messageGroup = group;
+        const messageGroupClassNameArray = classNamesForGroup;
         group = [];
         return (
           <BubbleGroup
@@ -75,6 +81,7 @@ export default class ChatFeed extends React.Component {
             showSenderName={showSenderName}
             chatBubble={ChatBubble}
             bubbleStyles={bubbleStyles}
+            classNameArray={messageGroupClassNameArray.length > 0 ? messageGroupClassNameArray as [string] : undefined}
           />
         );
       }

--- a/src/ChatFeed/index.tsx
+++ b/src/ChatFeed/index.tsx
@@ -21,6 +21,7 @@ interface ChatFeedInterface {
     showSenderName?: boolean;
     chatBubble?: React.Component;
     classNameArray?: string[];
+    styleArray?: object[];
   };
 }
 
@@ -62,17 +63,24 @@ export default class ChatFeed extends React.Component {
 
     let group = [];
     let classNamesForGroup = [];
+    let stylesForGroup = [];
 
     const messageNodes = messages.map((message, index) => {
       group.push(message);
       if (this.props.classNameArray && this.props.classNameArray.length > index) {
-        classNamesForGroup.push(this.props.classNameArray[index])
+        classNamesForGroup.push(this.props.classNameArray[index]);
+      }
+      if (this.props.styleArray && this.props.styleArray.length > index) {
+        stylesForGroup.push(this.props.styleArray[index]);
       }
       // Find diff in message type or no more messages
       if (index === messages.length - 1 || messages[index + 1].id !== message.id) {
         const messageGroup = group;
         const messageGroupClassNameArray = classNamesForGroup;
+        const messageGroupStyleArray = stylesForGroup;
         group = [];
+        classNamesForGroup = [];
+        stylesForGroup = [];
         return (
           <BubbleGroup
             key={index}
@@ -82,6 +90,7 @@ export default class ChatFeed extends React.Component {
             chatBubble={ChatBubble}
             bubbleStyles={bubbleStyles}
             classNameArray={messageGroupClassNameArray.length > 0 ? messageGroupClassNameArray as [string] : undefined}
+            styleArray={messageGroupStyleArray.length > 0 ? messageGroupStyleArray as [object] : undefined}
           />
         );
       }


### PR DESCRIPTION
Want to pass tailwind classes down to the messages. This will give us a lot more control over the styling of chat bubbles.